### PR TITLE
Update BinaryProvider invocations

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -42,7 +42,7 @@ libcalceph = library_dependency("libcalceph")
 provides(Sources,URI("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-3.0.0.tar.gz"), libcalceph)
 
 provides(BuildProcess,Autotools(configure_options =
-    ["--enable-shared", "--disable-fortran", "--disable-python"],
-    libtarget=joinpath("src", "libcalceph.la")),libcalceph, os = :Unix)
+        ["--enable-shared", "--disable-fortran", "--disable-python"],
+        libtarget=joinpath("src", "libcalceph.la")),libcalceph, os = :Unix)
 
 @BinDeps.install Dict(:libcalceph => :libcalceph)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,10 +1,8 @@
 using BinaryProvider
 
 # This is where all binaries will get installed
-const prefix = Prefix(!isempty(ARGS) ? ARGS[1] : joinpath(@__DIR__,"usr"))
-
-libcalceph = LibraryProduct(prefix, "libcalceph")
-
+prefix = Prefix(!isempty(ARGS) ? ARGS[1] : joinpath(@__DIR__,"usr"))
+libcalceph = LibraryProduct(prefix, "libcalceph", :libcalceph)
 products = [libcalceph]
 
 
@@ -30,25 +28,20 @@ if platform_key() in keys(download_info)
         install(url, tarball_hash; prefix=prefix, force=true, verbose=true)
     end
 
-    # Finally, write out a deps.jl file that will contain mappings for each
-    # named product here: (there will be a "libfoo" variable and a "fooifier"
-    # variable, etc...)
-    @write_deps_file libcalceph
-    exit(0)
-end
+    # Write out our deps.jl file that will contain a `libcalceph`
+    write_deps_file(joinpath(@__DIR__, "deps.jl"), products)
+else
+    info("Could not find a binary for your platform $(triplet(platform_key())). Will attempt a build.")
 
-info("Could not find a binary for your platform $(Sys.MACHINE). Will attempt a build.")
+    using BinDeps
+    @BinDeps.setup
 
-using BinDeps
+    libcalceph = library_dependency("libcalceph")
+    provides(Sources,URI("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-3.0.0.tar.gz"), libcalceph)
 
-@BinDeps.setup
-
-libcalceph = library_dependency("libcalceph")
-
-provides(Sources,URI("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-3.0.0.tar.gz"), libcalceph)
-
-provides(BuildProcess,Autotools(configure_options =
+    provides(BuildProcess,Autotools(configure_options =
         ["--enable-shared", "--disable-fortran", "--disable-python"],
         libtarget=joinpath("src", "libcalceph.la")),libcalceph, os = :Unix)
 
-@BinDeps.install Dict(:libcalceph => :libcalceph)
+    @BinDeps.install Dict(:libcalceph => :libcalceph)
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,18 +30,19 @@ if platform_key() in keys(download_info)
 
     # Write out our deps.jl file that will contain a `libcalceph`
     write_deps_file(joinpath(@__DIR__, "deps.jl"), products)
-else
-    info("Could not find a binary for your platform $(triplet(platform_key())). Will attempt a build.")
-
-    using BinDeps
-    @BinDeps.setup
-
-    libcalceph = library_dependency("libcalceph")
-    provides(Sources,URI("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-3.0.0.tar.gz"), libcalceph)
-
-    provides(BuildProcess,Autotools(configure_options =
-        ["--enable-shared", "--disable-fortran", "--disable-python"],
-        libtarget=joinpath("src", "libcalceph.la")),libcalceph, os = :Unix)
-
-    @BinDeps.install Dict(:libcalceph => :libcalceph)
+    exit(0)
 end
+
+info("Could not find a binary for your platform $(triplet(platform_key())). Will attempt a build.")
+
+using BinDeps
+@BinDeps.setup
+
+libcalceph = library_dependency("libcalceph")
+provides(Sources,URI("https://www.imcce.fr/content/medias/recherche/equipes/asd/calceph/calceph-3.0.0.tar.gz"), libcalceph)
+
+provides(BuildProcess,Autotools(configure_options =
+    ["--enable-shared", "--disable-fortran", "--disable-python"],
+    libtarget=joinpath("src", "libcalceph.la")),libcalceph, os = :Unix)
+
+@BinDeps.install Dict(:libcalceph => :libcalceph)


### PR DESCRIPTION
The new version of `BinaryProvider` will not contain the backwards-compatibility shims that it has so far, so this updates CALCEPH.jl to no longer depend on the old ways of doing things (like using `@write_deps_file()` instead of `write_deps_file()`).